### PR TITLE
Add Interruptable Wait Operations and Wait-for-Message Tool to Discord MCP Server

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ A Model Context Protocol (MCP) server that enables LLMs to interact with Discord
 - Automatic server and channel discovery
 - Support for both channel names and IDs
 - Proper error handling and validation
-- Response timeout handling
+- Configurable response timeout
 
 ## Prerequisites
 
@@ -103,7 +103,7 @@ Parameters:
 - `channel`: Channel name (e.g., "general") or ID
 - `message`: Message content to send
 - `userId`: Discord user ID to wait for response from
-- `timeout` (optional): Timeout in milliseconds to wait for response (default: 60000)
+- `timeout` (optional): Timeout in milliseconds (default: 3600000ms = 60 minutes)
 
 Example:
 ```json
@@ -111,7 +111,7 @@ Example:
   "channel": "general",
   "message": "Hello! What do you think about this?",
   "userId": "123456789012345678",
-  "timeout": 30000
+  "timeout": 3600000
 }
 ```
 
@@ -189,7 +189,7 @@ Claude will use the appropriate tools to interact with Discord while asking for 
 - Environment variables should be properly secured
 - Token should never be committed to version control
 - Channel access is limited to channels the bot has been given access to
-- Response waiting is limited to specific users and includes timeouts
+- Response waiting is limited to specific users and includes configurable timeouts
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -5,10 +5,12 @@ A Model Context Protocol (MCP) server that enables LLMs to interact with Discord
 ## Features
 
 - Send messages to Discord channels
+- Send messages and wait for specific user responses
 - Read recent messages from channels
 - Automatic server and channel discovery
 - Support for both channel names and IDs
 - Proper error handling and validation
+- Response timeout handling
 
 ## Prerequisites
 
@@ -83,6 +85,56 @@ Example:
 }
 ```
 
+Response format:
+```json
+{
+  "messageId": "123456789012345678",
+  "content": "Hello from MCP!",
+  "channel": "#general",
+  "server": "My Server"
+}
+```
+
+### send-and-wait
+Sends a message to a specified Discord channel and waits for a response from a specific user.
+
+Parameters:
+- `server` (optional): Server name or ID (required if bot is in multiple servers)
+- `channel`: Channel name (e.g., "general") or ID
+- `message`: Message content to send
+- `userId`: Discord user ID to wait for response from
+- `timeout` (optional): Timeout in milliseconds to wait for response (default: 60000)
+
+Example:
+```json
+{
+  "channel": "general",
+  "message": "Hello! What do you think about this?",
+  "userId": "123456789012345678",
+  "timeout": 30000
+}
+```
+
+Response format:
+```json
+{
+  "sentMessage": {
+    "content": "Hello! What do you think about this?",
+    "messageId": "123456789012345678",
+    "channel": "#general",
+    "server": "My Server"
+  },
+  "response": {
+    "content": "I think that's a great idea!",
+    "author": {
+      "id": "123456789012345678",
+      "tag": "User#1234"
+    },
+    "timestamp": "2024-02-24T16:45:00.000Z"
+  }
+}
+```
+
 ### read-messages
 Reads recent messages from a specified Discord channel.
 
@@ -125,7 +177,8 @@ Here are some example interactions you can try with Claude after setting up the 
 
 1. "Can you read the last 5 messages from the general channel?"
 2. "Please send a message to the announcements channel saying 'Meeting starts in 10 minutes'"
-3. "What were the most recent messages in the development channel about the latest release?"
+3. "Send a question to the development channel and wait for the team lead (ID: 123456789) to respond"
+4. "Post the meeting agenda in the team channel"
 
 Claude will use the appropriate tools to interact with Discord while asking for your approval before sending any messages.
 
@@ -136,6 +189,7 @@ Claude will use the appropriate tools to interact with Discord while asking for 
 - Environment variables should be properly secured
 - Token should never be committed to version control
 - Channel access is limited to channels the bot has been given access to
+- Response waiting is limited to specific users and includes timeouts
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ A Model Context Protocol (MCP) server that enables LLMs to interact with Discord
 
 - Send messages to Discord channels
 - Send messages and wait for specific user responses
+- Wait for messages from specific users
+- Interruptable wait operations by primary user
 - Read recent messages from channels
 - Automatic server and channel discovery
 - Support for both channel names and IDs
@@ -16,6 +18,7 @@ A Model Context Protocol (MCP) server that enables LLMs to interact with Discord
 
 - Node.js 16.x or higher
 - A Discord bot token
+- Your Discord user ID (for primary user features)
 - The bot must be invited to your server with proper permissions:
   - Read Messages/View Channels
   - Send Messages
@@ -34,9 +37,10 @@ cd discordmcp
 npm install
 ```
 
-3. Create a `.env` file in the root directory with your Discord bot token:
+3. Create a `.env` file in the root directory with your Discord bot token and primary user ID:
 ```
 DISCORD_TOKEN=your_discord_bot_token_here
+DISCORD_PRIMARY_USER_ID=your_discord_user_id_here
 ```
 
 4. Build the server:
@@ -58,7 +62,8 @@ npm run build
       "command": "node",
       "args": ["path/to/discordmcp/build/index.js"],
       "env": {
-        "DISCORD_TOKEN": "your_discord_bot_token_here"
+        "DISCORD_TOKEN": "your_discord_bot_token_here",
+        "DISCORD_PRIMARY_USER_ID": "your_discord_user_id_here"
       }
     }
   }
@@ -96,7 +101,7 @@ Response format:
 ```
 
 ### send-and-wait
-Sends a message to a specified Discord channel and waits for a response from a specific user.
+Sends a message to a specified Discord channel and waits for a response from a specific user. Can be interrupted by the primary user.
 
 Parameters:
 - `server` (optional): Server name or ID (required if bot is in multiple servers)
@@ -130,8 +135,46 @@ Response format:
       "id": "123456789012345678",
       "tag": "User#1234"
     },
-    "timestamp": "2024-02-24T16:45:00.000Z"
-  }
+    "timestamp": "2024-02-24T16:45:00.000Z",
+    "interrupted": false
+  },
+  "status": "completed"
+}
+```
+
+### wait-for-message
+Waits for a message from a specific user in a channel. Can be interrupted by the primary user.
+
+Parameters:
+- `server` (optional): Server name or ID (required if bot is in multiple servers)
+- `channel`: Channel name (e.g., "general") or ID
+- `userId`: Discord user ID to wait for message from
+- `timeout` (optional): Timeout in milliseconds (default: 3600000ms = 60 minutes)
+
+Example:
+```json
+{
+  "channel": "general",
+  "userId": "123456789012345678",
+  "timeout": 3600000
+}
+```
+
+Response format:
+```json
+{
+  "message": {
+    "content": "Here's my message",
+    "author": {
+      "id": "123456789012345678",
+      "tag": "User#1234"
+    },
+    "timestamp": "2024-02-24T16:45:00.000Z",
+    "interrupted": false
+  },
+  "channel": "#general",
+  "server": "My Server",
+  "status": "completed"
 }
 ```
 
@@ -178,9 +221,18 @@ Here are some example interactions you can try with Claude after setting up the 
 1. "Can you read the last 5 messages from the general channel?"
 2. "Please send a message to the announcements channel saying 'Meeting starts in 10 minutes'"
 3. "Send a question to the development channel and wait for the team lead (ID: 123456789) to respond"
-4. "Post the meeting agenda in the team channel"
+4. "Wait for any message from user 123456789 in the general channel"
+5. "Post the meeting agenda in the team channel"
 
 Claude will use the appropriate tools to interact with Discord while asking for your approval before sending any messages.
+
+## Primary User Features
+
+The primary user (configured via DISCORD_PRIMARY_USER_ID) has special privileges:
+
+1. Can interrupt any waiting operation by sending a message
+2. When a wait is interrupted, the response includes an `interrupted: true` flag
+3. Useful for canceling long-running wait operations or taking over conversations
 
 ## Security Considerations
 
@@ -190,6 +242,7 @@ Claude will use the appropriate tools to interact with Discord while asking for 
 - Token should never be committed to version control
 - Channel access is limited to channels the bot has been given access to
 - Response waiting is limited to specific users and includes configurable timeouts
+- Primary user ID should be properly secured and belong to a trusted user
 
 ## Contributing
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "zod": "^3.22.4"
       },
       "devDependencies": {
-        "@types/node": "^20.11.16",
+        "@types/node": "^20.17.19",
         "typescript": "^5.3.3"
       }
     },
@@ -195,10 +195,9 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "20.17.14",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.17.14.tgz",
-      "integrity": "sha512-w6qdYetNL5KRBiSClK/KWai+2IMEJuAj+EujKCumalFOwXtvOXaEan9AuwcRID2IcOIAWSIfR495hBtgKlx2zg==",
-      "license": "MIT",
+      "version": "20.17.19",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.17.19.tgz",
+      "integrity": "sha512-LEwC7o1ifqg/6r2gn9Dns0f1rhK+fPFDoMiceTJ6kWmVk6bgXBI/9IOWfVan4WiAavK9pIVWdX0/e3J+eEUh5A==",
       "dependencies": {
         "undici-types": "~6.19.2"
       }

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "main": "build/index.js",
   "scripts": {
-    "build": "tsc",
+    "build": "tsc && node -e \"require('fs').chmodSync('build/index.js', '755')\"",
     "start": "node build/index.js",
     "dev": "tsc -w",
     "test": "echo \"Error: no test specified\" && exit 1"
@@ -24,7 +24,7 @@
     "zod": "^3.22.4"
   },
   "devDependencies": {
-    "@types/node": "^20.11.16",
+    "@types/node": "^20.17.19",
     "typescript": "^5.3.3"
   }
 }

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -7,6 +7,7 @@ export const client = new Client({
     GatewayIntentBits.Guilds,
     GatewayIntentBits.GuildMessages,
     GatewayIntentBits.MessageContent,
+    GatewayIntentBits.DirectMessages,
   ],
 });
 
@@ -15,6 +16,11 @@ export async function initializeClient(): Promise<void> {
   // Set up event handlers
   client.once('ready', () => {
     console.error('Discord bot is ready!');
+  });
+
+  // Handle errors
+  client.on('error', (error) => {
+    console.error('Discord client error:', error);
   });
 
   // Login to Discord

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -15,7 +15,7 @@ export const client = new Client({
 export async function initializeClient(): Promise<void> {
   // Set up event handlers
   client.once('ready', () => {
-    console.error('Discord bot is ready!');
+    console.log('Discord bot is ready!');
   });
 
   // Handle errors

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -1,0 +1,22 @@
+import { Client, GatewayIntentBits } from 'discord.js';
+import { config } from '../config/env.js';
+
+// Create Discord client instance
+export const client = new Client({
+  intents: [
+    GatewayIntentBits.Guilds,
+    GatewayIntentBits.GuildMessages,
+    GatewayIntentBits.MessageContent,
+  ],
+});
+
+// Initialize Discord client
+export async function initializeClient(): Promise<void> {
+  // Set up event handlers
+  client.once('ready', () => {
+    console.error('Discord bot is ready!');
+  });
+
+  // Login to Discord
+  await client.login(config.discord.token);
+}

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -13,10 +13,17 @@ export const config = {
 
 // Validate required environment variables
 export function validateEnv() {
+  const errors: string[] = [];
+
   if (!config.discord.token) {
-    throw new Error('DISCORD_TOKEN environment variable is not set');
+    errors.push('DISCORD_TOKEN environment variable is not set');
   }
+
   if (!config.discord.primaryUserId) {
-    throw new Error('DISCORD_PRIMARY_USER_ID environment variable is not set');
+    errors.push('DISCORD_PRIMARY_USER_ID environment variable is not set');
+  }
+
+  if (errors.length > 0) {
+    throw new Error('Environment validation failed:\n' + errors.join('\n'));
   }
 }

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -1,0 +1,18 @@
+import dotenv from 'dotenv';
+
+// Load environment variables
+dotenv.config();
+
+// Environment variables configuration
+export const config = {
+  discord: {
+    token: process.env.DISCORD_TOKEN,
+  },
+};
+
+// Validate required environment variables
+export function validateEnv() {
+  if (!config.discord.token) {
+    throw new Error('DISCORD_TOKEN environment variable is not set');
+  }
+}

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -7,6 +7,7 @@ dotenv.config();
 export const config = {
   discord: {
     token: process.env.DISCORD_TOKEN,
+    primaryUserId: process.env.DISCORD_PRIMARY_USER_ID,
   },
 };
 
@@ -14,5 +15,8 @@ export const config = {
 export function validateEnv() {
   if (!config.discord.token) {
     throw new Error('DISCORD_TOKEN environment variable is not set');
+  }
+  if (!config.discord.primaryUserId) {
+    throw new Error('DISCORD_PRIMARY_USER_ID environment variable is not set');
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,108 +1,10 @@
 import { Server } from "@modelcontextprotocol/sdk/server/index.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
-import dotenv from 'dotenv';
-import {
-  CallToolRequestSchema,
-  ListToolsRequestSchema,
-} from "@modelcontextprotocol/sdk/types.js";
-import { Client, GatewayIntentBits, TextChannel } from 'discord.js';
-import { z } from 'zod';
-
-// Load environment variables
-dotenv.config();
-
-// Discord client setup
-const client = new Client({
-  intents: [
-    GatewayIntentBits.Guilds,
-    GatewayIntentBits.GuildMessages,
-    GatewayIntentBits.MessageContent,
-  ],
-});
-
-// Helper function to find a guild by name or ID
-async function findGuild(guildIdentifier?: string) {
-  if (!guildIdentifier) {
-    // If no guild specified and bot is only in one guild, use that
-    if (client.guilds.cache.size === 1) {
-      return client.guilds.cache.first()!;
-    }
-    // List available guilds
-    const guildList = Array.from(client.guilds.cache.values())
-      .map(g => `"${g.name}"`).join(', ');
-    throw new Error(`Bot is in multiple servers. Please specify server name or ID. Available servers: ${guildList}`);
-  }
-
-  // Try to fetch by ID first
-  try {
-    const guild = await client.guilds.fetch(guildIdentifier);
-    if (guild) return guild;
-  } catch {
-    // If ID fetch fails, search by name
-    const guilds = client.guilds.cache.filter(
-      g => g.name.toLowerCase() === guildIdentifier.toLowerCase()
-    );
-    
-    if (guilds.size === 0) {
-      const availableGuilds = Array.from(client.guilds.cache.values())
-        .map(g => `"${g.name}"`).join(', ');
-      throw new Error(`Server "${guildIdentifier}" not found. Available servers: ${availableGuilds}`);
-    }
-    if (guilds.size > 1) {
-      const guildList = guilds.map(g => `${g.name} (ID: ${g.id})`).join(', ');
-      throw new Error(`Multiple servers found with name "${guildIdentifier}": ${guildList}. Please specify the server ID.`);
-    }
-    return guilds.first()!;
-  }
-  throw new Error(`Server "${guildIdentifier}" not found`);
-}
-
-// Helper function to find a channel by name or ID within a specific guild
-async function findChannel(channelIdentifier: string, guildIdentifier?: string): Promise<TextChannel> {
-  const guild = await findGuild(guildIdentifier);
-  
-  // First try to fetch by ID
-  try {
-    const channel = await client.channels.fetch(channelIdentifier);
-    if (channel instanceof TextChannel && channel.guild.id === guild.id) {
-      return channel;
-    }
-  } catch {
-    // If fetching by ID fails, search by name in the specified guild
-    const channels = guild.channels.cache.filter(
-      (channel): channel is TextChannel =>
-        channel instanceof TextChannel &&
-        (channel.name.toLowerCase() === channelIdentifier.toLowerCase() ||
-         channel.name.toLowerCase() === channelIdentifier.toLowerCase().replace('#', ''))
-    );
-
-    if (channels.size === 0) {
-      const availableChannels = guild.channels.cache
-        .filter((c): c is TextChannel => c instanceof TextChannel)
-        .map(c => `"#${c.name}"`).join(', ');
-      throw new Error(`Channel "${channelIdentifier}" not found in server "${guild.name}". Available channels: ${availableChannels}`);
-    }
-    if (channels.size > 1) {
-      const channelList = channels.map(c => `#${c.name} (${c.id})`).join(', ');
-      throw new Error(`Multiple channels found with name "${channelIdentifier}" in server "${guild.name}": ${channelList}. Please specify the channel ID.`);
-    }
-    return channels.first()!;
-  }
-  throw new Error(`Channel "${channelIdentifier}" is not a text channel or not found in server "${guild.name}"`);
-}
-
-// Updated validation schemas
-const SendMessageSchema = z.object({
-  server: z.string().optional().describe('Server name or ID (optional if bot is only in one server)'),
-  channel: z.string().describe('Channel name (e.g., "general") or ID'),
-  message: z.string(),
-});
-
-const ReadMessagesSchema = z.object({
-  server: z.string().optional().describe('Server name or ID (optional if bot is only in one server)'),
-  channel: z.string().describe('Channel name (e.g., "general") or ID'),
-  limit: z.number().min(1).max(100).default(50),
-});
+import { CallToolRequestSchema, ListToolsRequestSchema } from "@modelcontextprotocol/sdk/types.js";
+import { validateEnv } from './config/env.js';
+import { initializeClient } from './client/index.js';
+import { tools } from './server/tools.js';
+import { handleSendMessage, handleSendAndWait, handleReadMessages, handleError } from './server/handlers.js';
 
 // Create server instance
 const server = new Server(
@@ -118,57 +20,9 @@ const server = new Server(
 );
 
 // List available tools
-server.setRequestHandler(ListToolsRequestSchema, async () => {
-  return {
-    tools: [
-      {
-        name: "send-message",
-        description: "Send a message to a Discord channel",
-        inputSchema: {
-          type: "object",
-          properties: {
-            server: {
-              type: "string",
-              description: 'Server name or ID (optional if bot is only in one server)',
-            },
-            channel: {
-              type: "string",
-              description: 'Channel name (e.g., "general") or ID',
-            },
-            message: {
-              type: "string",
-              description: "Message content to send",
-            },
-          },
-          required: ["channel", "message"],
-        },
-      },
-      {
-        name: "read-messages",
-        description: "Read recent messages from a Discord channel",
-        inputSchema: {
-          type: "object",
-          properties: {
-            server: {
-              type: "string",
-              description: 'Server name or ID (optional if bot is only in one server)',
-            },
-            channel: {
-              type: "string",
-              description: 'Channel name (e.g., "general") or ID',
-            },
-            limit: {
-              type: "number",
-              description: "Number of messages to fetch (max 100)",
-              default: 50,
-            },
-          },
-          required: ["channel"],
-        },
-      },
-    ],
-  };
-});
+server.setRequestHandler(ListToolsRequestSchema, async () => ({
+  tools,
+}));
 
 // Handle tool execution
 server.setRequestHandler(CallToolRequestSchema, async (request) => {
@@ -176,71 +30,44 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
 
   try {
     switch (name) {
-      case "send-message": {
-        const { channel: channelIdentifier, message } = SendMessageSchema.parse(args);
-        const channel = await findChannel(channelIdentifier);
-        
-        const sent = await channel.send(message);
-        return {
-          content: [{
-            type: "text",
-            text: `Message sent successfully to #${channel.name} in ${channel.guild.name}. Message ID: ${sent.id}`,
-          }],
-        };
-      }
+      case "send-message":
+        return await handleSendMessage(args);
 
-      case "read-messages": {
-        const { channel: channelIdentifier, limit } = ReadMessagesSchema.parse(args);
-        const channel = await findChannel(channelIdentifier);
-        
-        const messages = await channel.messages.fetch({ limit });
-        const formattedMessages = Array.from(messages.values()).map(msg => ({
-          channel: `#${channel.name}`,
-          server: channel.guild.name,
-          author: msg.author.tag,
-          content: msg.content,
-          timestamp: msg.createdAt.toISOString(),
-        }));
+      case "send-and-wait":
+        return await handleSendAndWait(args);
 
-        return {
-          content: [{
-            type: "text",
-            text: JSON.stringify(formattedMessages, null, 2),
-          }],
-        };
-      }
+      case "read-messages":
+        return await handleReadMessages(args);
 
       default:
-        throw new Error(`Unknown tool: ${name}`);
+        return {
+          content: [{
+            type: "text",
+            text: `Unknown tool: ${name}`,
+          }],
+          isError: true,
+        };
     }
   } catch (error) {
-    if (error instanceof z.ZodError) {
-      throw new Error(
-        `Invalid arguments: ${error.errors
-          .map((e) => `${e.path.join(".")}: ${e.message}`)
-          .join(", ")}`
-      );
-    }
-    throw error;
+    // Always return a proper response even in case of error
+    return {
+      content: [{
+        type: "text",
+        text: error instanceof Error ? error.message : String(error),
+      }],
+      isError: true,
+    };
   }
-});
-
-// Discord client login and error handling
-client.once('ready', () => {
-  console.error('Discord bot is ready!');
 });
 
 // Start the server
 async function main() {
-  // Check for Discord token
-  const token = process.env.DISCORD_TOKEN;
-  if (!token) {
-    throw new Error('DISCORD_TOKEN environment variable is not set');
-  }
-  
   try {
-    // Login to Discord
-    await client.login(token);
+    // Validate environment variables
+    validateEnv();
+    
+    // Initialize Discord client
+    await initializeClient();
 
     // Start MCP server
     const transport = new StdioServerTransport();

--- a/src/index.ts
+++ b/src/index.ts
@@ -84,7 +84,7 @@ async function main() {
     // Start MCP server
     const transport = new StdioServerTransport();
     await server.connect(transport);
-    console.error("Discord MCP Server running on stdio");
+    console.log("Discord MCP Server running on stdio");
   } catch (error) {
     console.error("Fatal error in main():", error);
     process.exit(1);
@@ -93,7 +93,7 @@ async function main() {
 
 // Handle cleanup on exit
 process.on('SIGINT', async () => {
-  console.error('Shutting down...');
+  console.log('Shutting down...');
   try {
     await server.close();
   } catch (error) {

--- a/src/server/handlers.ts
+++ b/src/server/handlers.ts
@@ -1,0 +1,105 @@
+import { z } from 'zod';
+import { client } from '../client/index.js';
+import { findChannel, waitForResponse } from '../utils/discord.js';
+import { SendMessageSchema, SendAndWaitSchema, ReadMessagesSchema } from '../types/schemas.js';
+
+export async function handleSendMessage(args: unknown) {
+  const { channel: channelIdentifier, message } = SendMessageSchema.parse(args);
+  const channel = await findChannel(client, channelIdentifier);
+  
+  // Send the message
+  const sent = await channel.send(message);
+  
+  return {
+    content: [{
+      type: "text",
+      text: JSON.stringify({
+        messageId: sent.id,
+        content: message,
+        channel: `#${channel.name}`,
+        server: channel.guild.name,
+      }, null, 2),
+    }],
+  };
+}
+
+export async function handleSendAndWait(args: unknown) {
+  const { channel: channelIdentifier, message, userId, timeout } = SendAndWaitSchema.parse(args);
+  const channel = await findChannel(client, channelIdentifier);
+  
+  // Send the message
+  const sent = await channel.send(message);
+  
+  try {
+    // Wait for response
+    const response = await waitForResponse(client, channel, userId, timeout);
+    
+    return {
+      content: [{
+        type: "text",
+        text: JSON.stringify({
+          sentMessage: {
+            content: message,
+            messageId: sent.id,
+            channel: `#${channel.name}`,
+            server: channel.guild.name,
+          },
+          response: {
+            content: response.content,
+            author: response.author,
+            timestamp: response.timestamp,
+          }
+        }, null, 2),
+      }],
+    };
+  } catch (error) {
+    // If timeout or other error occurs, still return the sent message info
+    return {
+      content: [{
+        type: "text",
+        text: JSON.stringify({
+          sentMessage: {
+            content: message,
+            messageId: sent.id,
+            channel: `#${channel.name}`,
+            server: channel.guild.name,
+          },
+          error: error instanceof Error ? error.message : 'Unknown error waiting for response',
+        }, null, 2),
+      }],
+      isError: true,
+    };
+  }
+}
+
+export async function handleReadMessages(args: unknown) {
+  const { channel: channelIdentifier, limit } = ReadMessagesSchema.parse(args);
+  const channel = await findChannel(client, channelIdentifier);
+  
+  const messages = await channel.messages.fetch({ limit });
+  const formattedMessages = Array.from(messages.values()).map(msg => ({
+    channel: `#${channel.name}`,
+    server: channel.guild.name,
+    author: msg.author.tag,
+    content: msg.content,
+    timestamp: msg.createdAt.toISOString(),
+  }));
+
+  return {
+    content: [{
+      type: "text",
+      text: JSON.stringify(formattedMessages, null, 2),
+    }],
+  };
+}
+
+export function handleError(error: unknown) {
+  if (error instanceof z.ZodError) {
+    throw new Error(
+      `Invalid arguments: ${error.errors
+        .map((e) => `${e.path.join(".")}: ${e.message}`)
+        .join(", ")}`
+    );
+  }
+  throw error;
+}

--- a/src/server/tools.ts
+++ b/src/server/tools.ts
@@ -47,8 +47,8 @@ export const tools: Tool[] = [
         },
         timeout: {
           type: "number",
-          description: "Timeout in milliseconds to wait for response (default: 60000)",
-          default: 60000,
+          description: "Timeout in milliseconds (default: 3600000ms = 60 minutes)",
+          default: 3600000,
         },
       },
       required: ["channel", "message", "userId"],

--- a/src/server/tools.ts
+++ b/src/server/tools.ts
@@ -1,0 +1,80 @@
+import { Tool } from '@modelcontextprotocol/sdk/types.js';
+
+export const tools: Tool[] = [
+  {
+    name: "send-message",
+    description: "Send a message to a Discord channel",
+    inputSchema: {
+      type: "object",
+      properties: {
+        server: {
+          type: "string",
+          description: 'Server name or ID (optional if bot is only in one server)',
+        },
+        channel: {
+          type: "string",
+          description: 'Channel name (e.g., "general") or ID',
+        },
+        message: {
+          type: "string",
+          description: "Message content to send",
+        },
+      },
+      required: ["channel", "message"],
+    },
+  },
+  {
+    name: "send-and-wait",
+    description: "Send a message to a Discord channel and wait for a response from a specific user",
+    inputSchema: {
+      type: "object",
+      properties: {
+        server: {
+          type: "string",
+          description: 'Server name or ID (optional if bot is only in one server)',
+        },
+        channel: {
+          type: "string",
+          description: 'Channel name (e.g., "general") or ID',
+        },
+        message: {
+          type: "string",
+          description: "Message content to send",
+        },
+        userId: {
+          type: "string",
+          description: "Discord user ID to wait for response from",
+        },
+        timeout: {
+          type: "number",
+          description: "Timeout in milliseconds to wait for response (default: 60000)",
+          default: 60000,
+        },
+      },
+      required: ["channel", "message", "userId"],
+    },
+  },
+  {
+    name: "read-messages",
+    description: "Read recent messages from a Discord channel",
+    inputSchema: {
+      type: "object",
+      properties: {
+        server: {
+          type: "string",
+          description: 'Server name or ID (optional if bot is only in one server)',
+        },
+        channel: {
+          type: "string",
+          description: 'Channel name (e.g., "general") or ID',
+        },
+        limit: {
+          type: "number",
+          description: "Number of messages to fetch (max 100)",
+          default: 50,
+        },
+      },
+      required: ["channel"],
+    },
+  },
+];

--- a/src/server/tools.ts
+++ b/src/server/tools.ts
@@ -55,6 +55,33 @@ export const tools: Tool[] = [
     },
   },
   {
+    name: "wait-for-message",
+    description: "Wait for a message from a specific user in a channel",
+    inputSchema: {
+      type: "object",
+      properties: {
+        server: {
+          type: "string",
+          description: 'Server name or ID (optional if bot is only in one server)',
+        },
+        channel: {
+          type: "string",
+          description: 'Channel name (e.g., "general") or ID',
+        },
+        userId: {
+          type: "string",
+          description: "Discord user ID to wait for message from",
+        },
+        timeout: {
+          type: "number",
+          description: "Timeout in milliseconds (default: 3600000ms = 60 minutes)",
+          default: 3600000,
+        },
+      },
+      required: ["channel", "userId"],
+    },
+  },
+  {
     name: "read-messages",
     description: "Read recent messages from a Discord channel",
     inputSchema: {

--- a/src/types/schemas.ts
+++ b/src/types/schemas.ts
@@ -11,7 +11,7 @@ export const SendAndWaitSchema = z.object({
   channel: z.string().describe('Channel name (e.g., "general") or ID'),
   message: z.string().describe('Message content to send'),
   userId: z.string().describe('Discord user ID to wait for response from'),
-  timeout: z.number().optional().default(60000).describe('Timeout in milliseconds to wait for response'),
+  timeout: z.number().optional().default(3600000).describe('Timeout in milliseconds (default: 3600000ms = 60 minutes)'),
 });
 
 export const ReadMessagesSchema = z.object({

--- a/src/types/schemas.ts
+++ b/src/types/schemas.ts
@@ -1,0 +1,30 @@
+import { z } from 'zod';
+
+export const SendMessageSchema = z.object({
+  server: z.string().optional().describe('Server name or ID (optional if bot is only in one server)'),
+  channel: z.string().describe('Channel name (e.g., "general") or ID'),
+  message: z.string().describe('Message content to send'),
+});
+
+export const SendAndWaitSchema = z.object({
+  server: z.string().optional().describe('Server name or ID (optional if bot is only in one server)'),
+  channel: z.string().describe('Channel name (e.g., "general") or ID'),
+  message: z.string().describe('Message content to send'),
+  userId: z.string().describe('Discord user ID to wait for response from'),
+  timeout: z.number().optional().default(60000).describe('Timeout in milliseconds to wait for response'),
+});
+
+export const ReadMessagesSchema = z.object({
+  server: z.string().optional().describe('Server name or ID (optional if bot is only in one server)'),
+  channel: z.string().describe('Channel name (e.g., "general") or ID'),
+  limit: z.number().min(1).max(100).default(50).describe('Number of messages to fetch (max 100)'),
+});
+
+export interface MessageResponse {
+  content: string;
+  author: {
+    id: string;
+    tag: string;
+  };
+  timestamp: string;
+}

--- a/src/types/schemas.ts
+++ b/src/types/schemas.ts
@@ -10,7 +10,14 @@ export const SendAndWaitSchema = z.object({
   server: z.string().optional().describe('Server name or ID (optional if bot is only in one server)'),
   channel: z.string().describe('Channel name (e.g., "general") or ID'),
   message: z.string().describe('Message content to send'),
-  userId: z.string().describe('Discord user ID to wait for response from'),
+  userId: z.string().describe('Discord user ID to wait for response from. Can be interrupted by primary user.'),
+  timeout: z.number().optional().default(3600000).describe('Timeout in milliseconds (default: 3600000ms = 60 minutes)'),
+});
+
+export const WaitForMessageSchema = z.object({
+  server: z.string().optional().describe('Server name or ID (optional if bot is only in one server)'),
+  channel: z.string().describe('Channel name (e.g., "general") or ID'),
+  userId: z.string().describe('Discord user ID to wait for message from. Can be interrupted by primary user.'),
   timeout: z.number().optional().default(3600000).describe('Timeout in milliseconds (default: 3600000ms = 60 minutes)'),
 });
 
@@ -27,4 +34,5 @@ export interface MessageResponse {
     tag: string;
   };
   timestamp: string;
+  interrupted?: boolean;
 }

--- a/src/utils/discord.ts
+++ b/src/utils/discord.ts
@@ -1,0 +1,106 @@
+import { Client, Guild, TextChannel, Message } from 'discord.js';
+import { MessageResponse } from '../types/schemas.js';
+
+export async function findGuild(client: Client, guildIdentifier?: string): Promise<Guild> {
+  if (!guildIdentifier) {
+    // If no guild specified and bot is only in one guild, use that
+    if (client.guilds.cache.size === 1) {
+      return client.guilds.cache.first()!;
+    }
+    // List available guilds
+    const guildList = Array.from(client.guilds.cache.values())
+      .map(g => `"${g.name}"`).join(', ');
+    throw new Error(`Bot is in multiple servers. Please specify server name or ID. Available servers: ${guildList}`);
+  }
+
+  // Try to fetch by ID first
+  try {
+    const guild = await client.guilds.fetch(guildIdentifier);
+    if (guild) return guild;
+  } catch {
+    // If ID fetch fails, search by name
+    const guilds = client.guilds.cache.filter(
+      g => g.name.toLowerCase() === guildIdentifier.toLowerCase()
+    );
+    
+    if (guilds.size === 0) {
+      const availableGuilds = Array.from(client.guilds.cache.values())
+        .map(g => `"${g.name}"`).join(', ');
+      throw new Error(`Server "${guildIdentifier}" not found. Available servers: ${availableGuilds}`);
+    }
+    if (guilds.size > 1) {
+      const guildList = guilds.map(g => `${g.name} (ID: ${g.id})`).join(', ');
+      throw new Error(`Multiple servers found with name "${guildIdentifier}": ${guildList}. Please specify the server ID.`);
+    }
+    return guilds.first()!;
+  }
+  throw new Error(`Server "${guildIdentifier}" not found`);
+}
+
+export async function findChannel(client: Client, channelIdentifier: string, guildIdentifier?: string): Promise<TextChannel> {
+  const guild = await findGuild(client, guildIdentifier);
+  
+  // First try to fetch by ID
+  try {
+    const channel = await client.channels.fetch(channelIdentifier);
+    if (channel instanceof TextChannel && channel.guild.id === guild.id) {
+      return channel;
+    }
+  } catch {
+    // If fetching by ID fails, search by name in the specified guild
+    const channels = guild.channels.cache.filter(
+      (channel): channel is TextChannel =>
+        channel instanceof TextChannel &&
+        (channel.name.toLowerCase() === channelIdentifier.toLowerCase() ||
+         channel.name.toLowerCase() === channelIdentifier.toLowerCase().replace('#', ''))
+    );
+
+    if (channels.size === 0) {
+      const availableChannels = guild.channels.cache
+        .filter((c): c is TextChannel => c instanceof TextChannel)
+        .map(c => `"#${c.name}"`).join(', ');
+      throw new Error(`Channel "${channelIdentifier}" not found in server "${guild.name}". Available channels: ${availableChannels}`);
+    }
+    if (channels.size > 1) {
+      const channelList = channels.map(c => `#${c.name} (${c.id})`).join(', ');
+      throw new Error(`Multiple channels found with name "${channelIdentifier}" in server "${guild.name}": ${channelList}. Please specify the channel ID.`);
+    }
+    return channels.first()!;
+  }
+  throw new Error(`Channel "${channelIdentifier}" is not a text channel or not found in server "${guild.name}"`);
+}
+
+export function waitForResponse(
+  client: Client,
+  channel: TextChannel,
+  userId: string,
+  timeout: number = 60000
+): Promise<MessageResponse> {
+  return new Promise((resolve, reject) => {
+    const timeoutId = setTimeout(() => {
+      cleanup();
+      reject(new Error(`Timeout waiting for response from user ${userId}`));
+    }, timeout);
+
+    const messageHandler = (message: Message) => {
+      if (message.channelId === channel.id && message.author.id === userId) {
+        cleanup();
+        resolve({
+          content: message.content,
+          author: {
+            id: message.author.id,
+            tag: message.author.tag,
+          },
+          timestamp: message.createdAt.toISOString(),
+        });
+      }
+    };
+
+    const cleanup = () => {
+      clearTimeout(timeoutId);
+      client.off('messageCreate', messageHandler);
+    };
+
+    client.on('messageCreate', messageHandler);
+  });
+}

--- a/src/utils/discord.ts
+++ b/src/utils/discord.ts
@@ -1,5 +1,6 @@
 import { Client, Guild, TextChannel, Message } from 'discord.js';
 import { MessageResponse } from '../types/schemas.js';
+import { config } from '../config/env.js';
 
 export async function findGuild(client: Client, guildIdentifier?: string): Promise<Guild> {
   if (!guildIdentifier) {
@@ -83,16 +84,20 @@ export function waitForResponse(
     }, timeout);
 
     const messageHandler = (message: Message) => {
-      if (message.channelId === channel.id && message.author.id === userId) {
-        cleanup();
-        resolve({
-          content: message.content,
-          author: {
-            id: message.author.id,
-            tag: message.author.tag,
-          },
-          timestamp: message.createdAt.toISOString(),
-        });
+      if (message.channelId === channel.id) {
+        // Check if message is from expected user or primary user
+        if (message.author.id === userId || message.author.id === config.discord.primaryUserId) {
+          cleanup();
+          resolve({
+            content: message.content,
+            author: {
+              id: message.author.id,
+              tag: message.author.tag,
+            },
+            timestamp: message.createdAt.toISOString(),
+            interrupted: message.author.id === config.discord.primaryUserId
+          });
+        }
       }
     };
 


### PR DESCRIPTION
This pull request enhances the Discord MCP server by splitting the message sending functionality into two separate tools, improving response waiting capabilities, and adding new features for interruptable wait operations and a wait-for-message tool.

## Changes
- **Split message functionality into two distinct tools:**
  - `send-message`: Simple message sending without waiting
  - `send-and-wait`: Send message and wait for specific user response
- **Reorganized codebase for better maintainability:**
  - Separated schemas into dedicated types
  - Split handlers into individual functions
- Improved error handling and response formats
- Set default timeout for `send-and-wait` to 60 minutes
- Updated documentation with new tools and examples

## New Features
### Interruptable Wait Operations
- Adds `DISCORD_PRIMARY_USER_ID` configuration to identify a primary user
- Primary user can interrupt any waiting operation by sending a message
- Interrupted operations are clearly marked in responses
- Enhances control over long-running wait operations

### New Wait-for-Message Tool
- Adds ability to wait for messages without sending anything
- Supports the same interruption capabilities as send-and-wait
- Useful for monitoring channels or waiting for specific user input
- Full timeout support and error handling

## Technical Details
- Added new `SendAndWaitSchema` with configurable timeout
- Implemented `waitForResponse` utility function
- Added proper TypeScript types for message responses
- Improved error handling for timeouts and edge cases
- Added primary user ID to environment configuration
- Extended `MessageResponse` interface with interrupted flag
- Modified `waitForResponse` to handle interruptions
- Added new `WaitForMessageSchema` and handler
- Updated documentation with new features and examples