### PR TITLE
Fix: pass server argument through to findChannel in both tool handlers

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -177,8 +177,8 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
   try {
     switch (name) {
       case "send-message": {
-        const { channel: channelIdentifier, message } = SendMessageSchema.parse(args);
-        const channel = await findChannel(channelIdentifier);
+        const { server: serverIdentifier, channel: channelIdentifier, message } = SendMessageSchema.parse(args);
+        const channel = await findChannel(channelIdentifier, serverIdentifier);
         
         const sent = await channel.send(message);
         return {
@@ -190,8 +190,8 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
       }
 
       case "read-messages": {
-        const { channel: channelIdentifier, limit } = ReadMessagesSchema.parse(args);
-        const channel = await findChannel(channelIdentifier);
+        const { server: serverIdentifier, channel: channelIdentifier, limit } = ReadMessagesSchema.parse(args);
+        const channel = await findChannel(channelIdentifier, serverIdentifier);
         
         const messages = await channel.messages.fetch({ limit });
         const formattedMessages = Array.from(messages.values()).map(msg => ({


### PR DESCRIPTION
## Problem
When the bot is a member of more than one Discord server, both `send-message` and `read-messages` fail with:

> Bot is in multiple servers. Please specify server name or ID. Available servers: ...

**even when the caller did provide a valid `server` argument.**

## Root cause
`SendMessageSchema` and `ReadMessagesSchema` both define an optional `server` field, but the `CallToolRequestSchema` handlers destructure only `channel`/`message`/`limit` and drop `server`:

```ts
const { channel: channelIdentifier, message } = SendMessageSchema.parse(args);
const channel = await findChannel(channelIdentifier);   // <- no guild passed
```

`findChannel(channelIdentifier)` then calls `findGuild(undefined)`, which throws "Bot is in multiple servers" (`src/index.ts` L33) regardless of the supplied `server`.

## Fix
Thread the parsed server identifier through to `findChannel(channel, server)` in both handlers. `findChannel` already accepts an optional `guildIdentifier` and forwards it to `findGuild`, so no signature change is needed. The destructured binding is named `serverIdentifier` to avoid shadowing the module-level `server` Server instance.

## Testing
- `npx tsc --noEmit` passes.
- Single-server use is unchanged — `server` stays optional and `findGuild(undefined)` still auto-selects the sole guild.
- Multi-server use now resolves the named/ID'd guild instead of throwing.

Two changed lines per handler; no behavioral change for single-guild bots.
